### PR TITLE
Add workflow_dispatch publishing trigger

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,7 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - "main"


### PR DESCRIPTION
This enables users to trigger the publishing process manually. 

This is useful when getting a new documentation repository up and running for the first time. It could also be handy if intermittent network errors cause the publishing process to fail (e.g. the link checker thinks a link is broken, but the target site is just down temporarily).