### PR TITLE
Use publisher image v0.8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:0.7
+      image: ministryofjustice/tech-docs-github-pages-publisher:0.8
     steps:
     - uses: actions/checkout@v2
     - name: Publish


### PR DESCRIPTION
This version doesn't spam "URI.unescape is obsolete" warnings, and also doesn't consider links to `/[repo name]` to be broken (which is important, because that's the root of the published website, on github pages)