### PR TITLE
Remove multipage-nav option

### DIFF
--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -16,9 +16,6 @@ enable_search: true
 # Tracking ID from Google Analytics (e.g. UA-XXXX-Y)
 ga_tracking_id:
 
-# Enable multipage navigation in the sidebar
-multipage_nav: false
-
 # Enable collapsible navigation in the sidebar
 collapsible_nav: false
 


### PR DESCRIPTION
Multipage navigation doesn't work with this version of the tech-docs gem (and/or it doesn't work with sites that aren't hosted at `/`).

I'm removing this option from the config file that users will see, so that people don't think it's an option they can use. It defaults to `false` so this should be fine.

There might be a way of getting it to work using the `http-prefix` option. This can either be supplied as a command-line option to middleman, like this;
```
middleman build ... --http-prefix=xxxxx
```

Or, in the `config.rb` file (which comes from the publisher docker image), like this:
```
configure :build do
  set :http_prefix, '/tech-docs'
end
```
I tried a few things, but couldn't get this to play nicely with the site being hosted at `/repo-name` rather than `/` (and I don't know if it works with search either).

If you plan on enabling multipage nav as an option for this project, I'd start by looking at that option.