### PR TITLE
Update docker image to 1.4

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -10,7 +10,7 @@ jobs:
   check_links:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.3
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.4
     steps:
     - uses: actions/checkout@v2
     - name: htmlproofer

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:1.3
+      image: ministryofjustice/tech-docs-github-pages-publisher:1.4
     steps:
     - uses: actions/checkout@v2
     - name: Publish

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.3
+IMAGE := ministryofjustice/tech-docs-github-pages-publisher:1.4
 
 # Use this to run a local instance of the documentation site, while editing
 .PHONY: preview


### PR DESCRIPTION
Updates the workflows and makefile to use [tech-docs-github-pages-publisher 1.4](https://github.com/ministryofjustice/tech-docs-github-pages-publisher/releases/tag/1.4).