### PR TITLE
🔗 Fix partial links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 ---
-name: 🧪 Test
+name: Test
 
 on:
   pull_request:

--- a/source/legacy-tdt-documentation/partials/_links.erb
+++ b/source/legacy-tdt-documentation/partials/_links.erb
@@ -1,29 +1,29 @@
 [Apple Developer Downloads]: https://developer.apple.com/downloads/
 
 [bundle-update]: https://bundler.io/v2.0/man/bundle-update.1.html
-[before-you-start]: /legacy-tdt-documentation/create_project/get_started/#get-started
-[build-your-docs]: /legacy-tdt-documentation/create_project/build/#build-your-documentation
+[before-you-start]: /template-documentation-site/legacy-tdt-documentation/create_project/get_started/#get-started
+[build-your-docs]: /template-documentation-site/legacy-tdt-documentation/create_project/build/#build-your-documentation
 
 [cf]: https://www.cloudfoundry.org
 [contact-email]: mailto:technical-writers@digital.cabinet-office.gov.uk
-[create-project]: /legacy-tdt-documentation/create_project/create_new_project/#create-a-new-documentation-project
+[create-project]: /template-documentation-site/legacy-tdt-documentation/create_project/create_new_project/#create-a-new-documentation-project
 
 [daniel-github]: https://github.com/alphagov/tech-docs-monitor
 [daniel-set-up]: https://github.com/alphagov/tech-docs-monitor#usage
 [daniel-set-up-pr]: https://github.com/alphagov/tech-docs-monitor/pull/12
 [design-system]: https://design-system.service.gov.uk/components/warning-text/
 [docs-as-code-blog]: https://gdstechnology.blog.gov.uk/2017/08/25/why-we-use-a-docs-as-code-approach-for-technical-documentation
-[deploy-and-host]: /legacy-tdt-documentation/publish_project/deploy/#deploy-and-host-your-documentation-site
+[deploy-and-host]: /template-documentation-site/legacy-tdt-documentation/publish_project/deploy/#deploy-and-host-your-documentation-site
 
-[expiry]: /legacy-tdt-documentation/configure_project/page_expiry_and_review/#set-review-date-for-pages
+[expiry]: /template-documentation-site/legacy-tdt-documentation/configure_project/page_expiry_and_review/#set-review-date-for-pages
 
-[frontmatter]: /legacy-tdt-documentation/configure_project/frontmatter/#configure-page-settings
+[frontmatter]: /template-documentation-site/legacy-tdt-documentation/configure_project/frontmatter/#configure-page-settings
 
 [GDS Web Help Desk]: https://gdshelpdesk.digital.cabinet-office.gov.uk/helpdesk/WebObjects/Helpdesk.woa
-[github_repo]: /legacy-tdt-documentation/configure_project/global_configuration/#github-repo
+[github_repo]: /template-documentation-site/legacy-tdt-documentation/configure_project/global_configuration/#github-repo
 [gh-pages]: https://pages.github.com
 [gh-pages-example]: https://github.com/ministryofjustice/cloud-platform-user-guide
-[global-config]: /legacy-tdt-documentation/configure_project/global_configuration/#configure-your-documentation-site
+[global-config]: /template-documentation-site/legacy-tdt-documentation/configure_project/global_configuration/#configure-your-documentation-site
 [global-config-example]: https://github.com/alphagov/paas-tech-docs/blob/main/config/tech-docs.yml
 [Google Site Verification code]: https://support.google.com/webmasters/answer/35179?hl=en
 
@@ -37,45 +37,45 @@
 [nested-example-code]: https://github.com/alphagov/pay-tech-docs/tree/master/source/switching_to_live
 [node]: https://nodejs.org/en/
 
-[old-paths]: /legacy-tdt-documentation/configure_project/frontmatter/#old-paths
+[old-paths]: /template-documentation-site/legacy-tdt-documentation/configure_project/frontmatter/#old-paths
 [openapi3-spec]: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md
-[openapi3]: /legacy-tdt-documentation/write_docs/add_openapi_spec/#convert-an-openapi-specification-into-documentation
+[openapi3]: /template-documentation-site/legacy-tdt-documentation/write_docs/add_openapi_spec/#convert-an-openapi-specification-into-documentation
 
 [paas]: https://www.cloud.service.gov.uk
 [paas-docs]: https://docs.cloud.service.gov.uk
 [paas-docs-ci]: https://docs.cloud.service.gov.uk/using_ci.html#configuring-a-continuous-integration-ci-tool
 [pay-docs]: https://docs.payments.service.gov.uk
-[preview-your-docs]: /legacy-tdt-documentation/create_project/preview/#preview-your-documentation
+[preview-your-docs]: /template-documentation-site/legacy-tdt-documentation/create_project/preview/#preview-your-documentation
 
 [rbenv]: https://github.com/rbenv/rbenv
-[redirects]: /legacy-tdt-documentation/maintain_project/redirects/#set-up-redirects
+[redirects]: /template-documentation-site/legacy-tdt-documentation/maintain_project/redirects/#set-up-redirects
 [redirect-configrb]: https://middlemanapp.com/basics/redirects
-[redirect-frontmatter]: /legacy-tdt-documentation/configure_project/frontmatter/#old-paths
-[redirect-global]: /legacy-tdt-documentation/config_project/configuration/#redirects
-[review-content]: /legacy-tdt-documentation/maintain_project/review_content/#set-up-regular-content-reviews
-[review-in]: /legacy-tdt-documentation/configure_project/frontmatter/#quot-last-reviewed-on-quot-and-quot-review-in-quot
+[redirect-frontmatter]: /template-documentation-site/legacy-tdt-documentation/configure_project/frontmatter/#old-paths
+[redirect-global]: /template-documentation-site/legacy-tdt-documentation/config_project/configuration/#redirects
+[review-content]: /template-documentation-site/legacy-tdt-documentation/maintain_project/review_content/#set-up-regular-content-reviews
+[review-in]: /template-documentation-site/legacy-tdt-documentation/configure_project/frontmatter/#quot-last-reviewed-on-quot-and-quot-review-in-quot
 [ruby]: https://www.ruby-lang.org/en
 [ruby-downloads]: https://www.ruby-lang.org/en/downloads
 [rvm]: https://rvm.io/
 
-[search-feature]: /legacy-tdt-documentation/configure_project/global_configuration/#enable-search
+[search-feature]: /template-documentation-site/legacy-tdt-documentation/configure_project/global_configuration/#enable-search
 [single-page-example]: https://docs.notifications.service.gov.uk/java.html
 [slack-tech-docs-format]: https://gds.slack.com/messages/CADK8N58B
 [slack-ask-tw]: https://gds.slack.com/messages/CAD579Y1X
-[structure-your-docs]: /legacy-tdt-documentation/configure_project/structure_docs/#structure-your-documentation
+[structure-your-docs]: /template-documentation-site/legacy-tdt-documentation/configure_project/structure_docs/#structure-your-documentation
 
-[show_contribution_banner]: /legacy-tdt-documentation/configure_project/global_configuration/#show-contribution-banner
+[show_contribution_banner]: /template-documentation-site/legacy-tdt-documentation/configure_project/global_configuration/#show-contribution-banner
 
 [tech-docs-gem]: https://github.com/alphagov/tech-docs-gem
 [tech-docs-gem-dependents]: https://github.com/alphagov/tech-docs-gem/network/dependents
 [tech-docs-template]: https://github.com/alphagov/tech-docs-template
 [template-issues]: https://github.com/alphagov/tech-docs-template/issues
 
-[use-latest-template]: /legacy-tdt-documentation/maintain_project/use_latest_template/#use-the-latest-template-version
+[use-latest-template]: /template-documentation-site/legacy-tdt-documentation/maintain_project/use_latest_template/#use-the-latest-template-version
 [use-openapi]: https://www.gov.uk/government/publications/recommended-open-standards-for-government/describing-restful-apis-with-openapi-3
 
-[version-control]: /legacy-tdt-documentation/publish_project/version/#use-version-control
+[version-control]: /template-documentation-site/legacy-tdt-documentation/publish_project/version/#use-version-control
 
-[write-content]: /legacy-tdt-documentation/write_docs/content/#write-your-content
+[write-content]: /template-documentation-site/legacy-tdt-documentation/write_docs/content/#write-your-content
 
 [xcode]: https://developer.apple.com/xcode


### PR DESCRIPTION
This pull request:

- Prefixes partial links with `/template-documentation-site/` because they render wrong e.g. https://ministryofjustice.github.io/legacy-tdt-documentation/configure_project/global_configuration/#configure-your-documentation-site when it should be https://ministryofjustice.github.io/template-documentation-site/legacy-tdt-documentation/configure_project/global_configuration/#configure-your-documentation-site
  - This was missed when developing locally because it runs from a folder when deployed to GitHub Pages
- Removes 🧪 emoji from testing workflow, not everyone likes them!

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 