### PR TITLE
📌 Update to 6.0.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:30d00879b5c82afa5d76264164db46189fa11d4358b37ca35b6a62e341d62bb7 # v5.1.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:0b9c705b053850f47908e9691f3b77212c5f85bee7db5f0938feb634485ef05b # v6.0.0
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:30d00879b5c82afa5d76264164db46189fa11d4358b37ca35b6a62e341d62bb7 # v5.1.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:0b9c705b053850f47908e9691f3b77212c5f85bee7db5f0938feb634485ef05b # v6.0.0
     permissions:
       contents: read
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .DEFAULT_GOAL := preview
 
 TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE     ?= ghcr.io/ministryofjustice/tech-docs-github-pages-publisher
-TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA ?= sha256:30d00879b5c82afa5d76264164db46189fa11d4358b37ca35b6a62e341d62bb7 # v5.1.0
+TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA ?= sha256:0b9c705b053850f47908e9691f3b77212c5f85bee7db5f0938feb634485ef05b # v6.0.0
 
 package:
 	docker run --rm \


### PR DESCRIPTION
## Proposed Changes

- Updates `ghcr.io/ministryofjustice/tech-docs-github-pages-publisher` to [v6.0.0](https://github.com/ministryofjustice/tech-docs-github-pages-publisher/releases/tag/v6.0.0)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>