### PR TITLE
⬆️ Update to v6.0.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:0b9c705b053850f47908e9691f3b77212c5f85bee7db5f0938feb634485ef05b # v6.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:c55eb7a18eb667a2e616e16cf0918b26c1932fc03e6ad8e9bfe6961fd746692e # v6.0.1
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:0b9c705b053850f47908e9691f3b77212c5f85bee7db5f0938feb634485ef05b # v6.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:c55eb7a18eb667a2e616e16cf0918b26c1932fc03e6ad8e9bfe6961fd746692e # v6.0.1
     permissions:
       contents: read
     steps:

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -11,3 +11,4 @@ https://www.larry-the-cat.service.gov.uk
 http://www.htaccesstools.com/htpasswd-generator
 https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml
 https://tdt-documentation.london.cloudapps.digital
+https://digitalaccessibilitycentre.org

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -10,3 +10,4 @@ https://github-community.service.justice.gov.uk/repository-standards/template-do
 https://www.larry-the-cat.service.gov.uk
 http://www.htaccesstools.com/htpasswd-generator
 https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml
+https://tdt-documentation.london.cloudapps.digital

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .DEFAULT_GOAL := preview
 
 TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE     ?= ghcr.io/ministryofjustice/tech-docs-github-pages-publisher
-TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA ?= sha256:0b9c705b053850f47908e9691f3b77212c5f85bee7db5f0938feb634485ef05b # v6.0.0
+TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA ?= sha256:c55eb7a18eb667a2e616e16cf0918b26c1932fc03e6ad8e9bfe6961fd746692e # v6.0.1
 
 package:
 	docker run --rm \


### PR DESCRIPTION
## Proposed Changes

- Updates `ghcr.io/ministryofjustice/tech-docs-github-pages-publisher` to [`v6.0.1`](https://github.com/ministryofjustice/tech-docs-github-pages-publisher/releases/tag/v6.0.1)

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>