### PR TITLE
Bump to v6.2.0-1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e # v6.2.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:7c0508cf2d199c1b3f0f67e4872023d5399425fead9b2bb2ca461f72c5f409a3 # v6.2.0-1
     permissions:
       contents: read
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e # v6.2.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:7c0508cf2d199c1b3f0f67e4872023d5399425fead9b2bb2ca461f72c5f409a3 # v6.2.0-1
     permissions:
       contents: read
     steps:
@@ -27,22 +27,3 @@ jobs:
         id: build
         run: |
           /usr/local/bin/package
-
-  link-checker:
-    name: Link Checker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-
-      - name: Lychee
-        id: lychee
-        uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
-        with:
-          args: --verbose --no-progress './**/*.md' './**/*.html' './**/*.erb' --accept 403,200,429
-          fail: true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 .DEFAULT_GOAL := preview
 
 TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE     ?= ghcr.io/ministryofjustice/tech-docs-github-pages-publisher
-TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA ?= sha256:8b00235edfa4d1248e3cdd08c022d5f398c7f4abb3315b6078f1e876214a171e # v6.2.0
+TECH_DOCS_GITHUB_PAGES_PUBLISHER_IMAGE_SHA ?= sha256:7c0508cf2d199c1b3f0f67e4872023d5399425fead9b2bb2ca461f72c5f409a3 # v6.2.0-1
 
 package:
 	docker run --rm \


### PR DESCRIPTION
## Proposed Changes

- Bumps publisher to https://github.com/ministryofjustice/tech-docs-github-pages-publisher/releases/tag/v6.2.0-1
- Removes Lychee

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>